### PR TITLE
Initialized usermappings key to avoid fullname error on Moodle 4.1

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -147,6 +147,11 @@ function assignsubmission_gradereviews_comment_display($gradereviews, $options) 
                 $gradereviewer->email = $guestuser->email;
                 $gradereviewer->imagealt = $guestuser->imagealt;
 
+                // Initialize $usermappings[$gradereview->userid] as an object if it's not already set.
+                if (!isset($usermappings[$gradereview->userid])) {
+                    $usermappings[$gradereview->userid] = new stdClass();
+                }
+
                 // Temporarily store blind-marking information for use in later gradereviews if necessary.
                 $usermappings[$gradereview->userid]->fullname = fullname($gradereviewer);
                 $usermappings[$gradereview->userid]->avatar = $assignment->get_renderer()->user_picture($gradereviewer,


### PR DESCRIPTION
Made sure the $usermappings key was initialized before setting it as this was producing an exception in Moodle 4.1

Exception - Attempt to assign property "fullname" on null line 151 of /mod/assign/submission/gradereviews/lib.php: Error thrown